### PR TITLE
fix: Ensure EJS layout is correctly applied

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs').promises; // Added fs.promises
 const marked = require('marked'); // Added marked
+const expressLayouts = require('express-ejs-layouts'); // Added express-ejs-layouts
 const fileService = require('./services/fileService');
 const searchService = require('./services/searchService');
 
@@ -11,6 +12,8 @@ const port = process.env.PORT || 3000;
 // View engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
+app.use(expressLayouts); // Use express-ejs-layouts
+// app.set('layout', 'layout'); // Optional: defaults to 'layout.ejs' in views directory
 
 // Static files
 app.use(express.static(path.join(__dirname, 'public')));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ejs": "^3.1.10",
         "express": "4.12.2",
+        "express-ejs-layouts": "^2.5.1",
         "fs-extra": "^11.3.0",
         "lunr": "^2.3.9",
         "marked": "^16.0.0"
@@ -240,6 +241,11 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-ejs-layouts": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/express-ejs-layouts/-/express-ejs-layouts-2.5.1.tgz",
+      "integrity": "sha512-IXROv9n3xKga7FowT06n1Qn927JR8ZWDn5Dc9CJQoiiaaDqbhW5PDmWShzbpAa2wjWT1vJqaIM1S6vJwwX11gA=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "express": "4.12.2",
     "fs-extra": "^11.3.0",
     "lunr": "^2.3.9",
-    "marked": "^16.0.0"
+    "marked": "^16.0.0",
+    "express-ejs-layouts": "^2.5.1"
   }
 }

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -77,43 +77,6 @@
     </div>
 
     <!-- Bootstrap JS Bundle with Popper -->
-            <%# <div class="search-bar"> ... </div> %>
-            <%# <hr> %>
-            <% function renderNav(items, basePath = '') { %>
-                <ul class="list-unstyled"> <%# Basic Bootstrap styling for lists %>
-                <% items.forEach(item => { %>
-                    <li>
-                        <% if (item.type === 'folder') { %>
-                            <strong><%= item.name %></strong>
-                            <% if (item.children && item.children.length > 0) { %>
-                                <%- renderNav(item.children, (basePath ? basePath + '/' : '') + item.name) %>
-                            <% } %>
-                        <% } else if (item.type === 'file') { %>
-                            <% const filePathForLink = item.relativePath.replace(/\\/g, '/'); %>
-                            <a href="/view/<%= filePathForLink %>"><%= item.name.replace('.md', '') %></a>
-                        <% } %>
-                    </li>
-                <% }); %>
-                </ul>
-            <% } %>
-
-            <% if (locals.directoryTree && locals.directoryTree.children) { %>
-                <%- renderNav(locals.directoryTree.children) %>
-            <% } else { %>
-                <p>No content found or error loading navigation.</p>
-            <% } %>
-        </nav>
-        <main class="content-pane">
-            <% if (typeof body !== 'undefined') { %>
-                <%- body %>
-            <% } else { %>
-                <h1>Welcome to the Wiki</h1>
-                <p>Select a document from the navigation to view its content.</p>
-            <% } %>
-        </main>
-    </div>
-
-    <!-- Bootstrap JS Bundle with Popper -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
     <script src="/js/main.js"></script> <!-- For search and other interactions -->
 </body>


### PR DESCRIPTION
- Added `express-ejs-layouts` dependency to manage EJS layouts.
- Configured `app.js` to use the `express-ejs-layouts` middleware. This ensures that `views/layout.ejs` is automatically used as the wrapper for other rendered views like `index.ejs` and `document.ejs`, injecting their content into the `body` variable.
- Removed a block of duplicated code from `views/layout.ejs` that was causing structural errors in the template.

These changes resolve the issue where only the content of `index.md` was being displayed without the surrounding page layout (header, navigation, etc.).