### PR TITLE
feat: Replace Unicode nav icons with Bootstrap Icons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -155,9 +155,17 @@ body {
 
 .navigation-pane .nav-icon {
     margin-right: 8px; /* Space between icon and text */
-    display: inline-block; /* Helps with alignment if needed */
-    width: 1em; /* Give icon a consistent width for alignment */
+    /* display: inline-block; */ /* Not strictly necessary for <i> if it behaves well */
+    /* width: 1em; */ /* Let the icon take its natural width, Bootstrap icons are square-ish */
+    vertical-align: text-bottom; /* Try to align icons better with text */
 }
+
+/* Ensure Bootstrap icons within nav-icon are not overly large or small */
+.navigation-pane .nav-icon > .bi {
+    font-size: 1em; /* Match the surrounding text size */
+    /* vertical-align: middle; */ /* Alternative alignment */
+}
+
 
 .navigation-pane li strong { /* Folder names - can keep specific styling for these */
     font-weight: 500;

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -6,6 +6,8 @@
     <title><%= typeof title !== 'undefined' ? title : 'Markdown Wiki' %> - My Wiki</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+    <!-- Bootstrap Icons CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
@@ -48,7 +50,7 @@
                     <li class="nav-item"> <%# Bootstrap nav item class %>
                         <% if (item.type === 'folder') { %>
                             <strong class="d-block" style="<%= itemStyle %>">
-                                <span class="nav-icon">📁</span> <%= item.name %>
+                                <span class="nav-icon"><i class="bi bi-folder-fill"></i></span> <%= item.name %>
                             </strong>
                             <% if (item.children && item.children.length > 0) { %>
                                 <%- renderNav(item.children, depth + 1) %> <%# Pass incremented depth %>
@@ -56,7 +58,7 @@
                         <% } else if (item.type === 'file') { %>
                             <% const filePathForLink = item.relativePath.replace(/\\/g, '/'); %>
                             <a class="nav-link" href="/view/<%= filePathForLink %>" style="<%= itemStyle %>">
-                                <span class="nav-icon">📄</span> <%= item.name.replace('.md', '') %>
+                                <span class="nav-icon"><i class="bi bi-file-earmark-text"></i></span> <%= item.name.replace('.md', '') %>
                             </a> <%# Bootstrap nav link class %>
                         <% } %>
                     </li>


### PR DESCRIPTION
- Added Bootstrap Icons CSS CDN to layout.ejs.
- Updated the navigation rendering logic (renderNav in layout.ejs) to use Bootstrap Icons (e.g., bi-folder-fill, bi-file-earmark-text) for folders and files, replacing the previous Unicode characters.
- Adjusted CSS for .nav-icon to ensure proper alignment and sizing of the Bootstrap Icons within the navigation tree.