### PR TITLE
Fix: Remove bottom margin from header to eliminate gap

### DIFF
--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -13,7 +13,7 @@
 <body>
     <%# Bootstrap JS and Popper.js will be added at the end of the body %>
 
-    <header class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <header class="navbar navbar-expand-lg navbar-dark bg-dark">
         <div class="container-fluid">
             <a class="navbar-brand" href="/">Atlas Knowledge Repository</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNavSearch" aria-controls="navbarNavSearch" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
Removes the `mb-4` Bootstrap utility class from the `<header>` element in `views/layout.ejs`. This change eliminates the unnecessary white space between the header and the main content area, allowing the left navigation and content panes to sit directly below the header.