### PR TITLE
Implement Node.js CLI for Markdown editing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
-# gemini-cli
-Looking at Googles gemini-ai functionality
+# Markdown Editor GitHub Tool (Node.js)
+
+This CLI tool allows users to clone a GitHub repository, list its markdown files, select a file to edit in their default system editor, and then commit and push the changes back to the GitHub repository.
+
+## Features
+
+-   **Clone or Pull Repositories:**
+    -   Clones a new repository if the specified local directory is empty or doesn't exist.
+    -   Pulls the latest changes if the local directory is an existing Git repository.
+-   **List Markdown Files:** Displays a list of all `.md` files found in the repository.
+-   **Interactive File Selection:** Allows the user to choose a markdown file from the list.
+-   **Open in Default Editor:** Opens the selected markdown file using the system's default application for `.md` files.
+-   **Commit Changes:**
+    -   Prompts the user to confirm they've saved changes.
+    -   Asks for a commit message.
+    -   Commits the selected file (or any staged changes if the selected file wasn't modified but other changes were staged).
+-   **Push Changes:** Pushes the committed changes to the `origin` remote on the current branch (will attempt to set upstream for the first push).
+-   **User-Friendly Prompts:** Guides the user through the workflow using interactive CLI prompts.
+-   **Error Handling:** Provides feedback for common Git errors (e.g., unconfigured user, authentication issues, need to pull).
+
+## Prerequisites
+
+1.  **Node.js and npm:** Ensure you have a recent version of Node.js installed (which includes npm). You can download it from [nodejs.org](https://nodejs.org/).
+2.  **Git:** The Git command-line tool must be installed and accessible in your system's PATH. You can download it from [git-scm.com](https://git-scm.com/).
+    *   **Git User Configuration:** It's highly recommended to configure your Git user name and email globally if you haven't already. This is required for making commits:
+        ```bash
+        git config --global user.name "Your Name"
+        git config --global user.email "youremail@example.com"
+        ```
+3.  **Default Markdown Editor:** Your operating system should have a default application associated with `.md` files for them to be opened automatically.
+
+## Setup
+
+1.  **Clone this Tool's Repository (or Download Files):**
+    ```bash
+    # If you have this project in a git repo:
+    # git clone <this-tool-repo-url>
+    # cd <this-tool-directory>
+
+    # Or, if you just have the app.js and package.json:
+    # Ensure app.js and package.json are in your current directory.
+    ```
+2.  **Navigate to the Project Directory:**
+    Open your terminal or command prompt and change to the directory where you placed the tool's files (e.g., where `app.js` and `package.json` are).
+3.  **Install Dependencies:**
+    Run the following command to install the necessary Node.js packages:
+    ```bash
+    npm install
+    ```
+
+## Usage
+
+1.  **Run the Application:**
+    Execute the script using Node.js:
+    ```bash
+    node app.js
+    ```
+2.  **Follow Prompts:**
+    *   **Repository URL:** Enter the HTTPS or SSH URL of the GitHub repository you want to work with.
+    *   **Local Path:** Specify a local directory where the repository will be cloned or where the existing clone resides. A default path (`./cloned_repo_nodejs`) is suggested.
+    *   The tool will then clone or pull the repository.
+    *   **Select File:** If markdown files are found, they will be listed. Select the one you wish to edit using the arrow keys and press Enter.
+    *   The selected file will open in your default markdown editor.
+    *   **Edit and Save:** Make your changes in the editor and save the file.
+    *   **Confirm Commit:** Back in the terminal, confirm if you have saved your changes and are ready to commit.
+    *   **Commit Message:** If you confirm, you'll be prompted to enter a commit message.
+    *   The tool will then attempt to commit and push your changes.
+    *   Follow any further instructions or error messages provided by the tool.
+
+## Dependencies Used
+
+-   `simple-git`: For programmatically executing Git commands.
+-   `inquirer`: For creating interactive command-line user prompts.
+-   `fs-extra`: For file system operations (like ensuring a directory exists).
+-   `open`: For opening files with the system's default application.
+
+---
+
+If you encounter issues, ensure your Git setup (authentication, configuration) is correct and that you have permissions for the target repository.

--- a/app.js
+++ b/app.js
@@ -1,151 +1,315 @@
-const express = require('express');
-const path = require('path');
-const fs = require('fs').promises; // Added fs.promises
-const marked = require('marked'); // Added marked
-const expressLayouts = require('express-ejs-layouts'); // Added express-ejs-layouts
-const fileService = require('./services/fileService');
-const searchService = require('./services/searchService');
+// Main application script for the Markdown Editor GitHub Tool (Node.js)
+import simpleGit from 'simple-git';
+import fs from 'fs-extra';
+import path from 'path';
+import inquirer from 'inquirer';
+import open from 'open'; // Added open package
 
-const app = express();
-const port = process.env.PORT || 3000;
+const git = simpleGit(); // This global instance might not be ideal if CWD changes are needed often.
+                         // Consider instantiating simpleGit() as needed or simpleGit(basePath) for specific operations.
 
-// View engine setup
-app.set('views', path.join(__dirname, 'views'));
-app.set('view engine', 'ejs');
-app.use(expressLayouts); // Use express-ejs-layouts
-// app.set('layout', 'layout'); // Optional: defaults to 'layout.ejs' in views directory
-
-// Static files
-app.use(express.static(path.join(__dirname, 'public')));
-
-// Content directory
-const contentDir = path.join(__dirname, 'content');
-
-// Global variable to store the directory tree and flag for initialization
-// Initialize with a default structure to prevent errors if initialization fails
-let siteDirectoryTree = {
-    name: path.basename(contentDir),
-    path: contentDir,
-    type: 'folder',
-    children: [],
-    relativePath: ''
-};
-let isInitialized = false;
-
-// Function to initialize directory tree and search index
-async function initializeApp() {
-    if (isInitialized) return; // Prevent re-initialization
-
+/**
+ * Clones a repository if the local path doesn't exist or is empty.
+ * @param {string} repoUrl - URL of the repository to clone.
+ * @param {string} localPath - Local path to clone into.
+ */
+async function cloneRepo(repoUrl, localPath) {
     try {
-        console.log("Initializing application data...");
-        // Perform operations on a temporary tree first
-        const tempTree = await fileService.getDirectoryTree(contentDir);
+        const CWD = process.cwd();
+        const targetPath = path.resolve(CWD, localPath);
 
-        // Function to make paths relative to contentDir for links (mutates the tree)
-        // This function needs to be defined here or accessible in this scope
-        function makePathsRelative(node, baseDir) {
-            if (node.path) {
-                node.relativePath = path.relative(baseDir, node.path);
-            }
-            if (node.children) {
-                node.children.forEach(child => makePathsRelative(child, baseDir));
-            }
+        if (await fs.pathExists(targetPath) && (await fs.readdir(targetPath)).length > 0) {
+            console.log(`Directory ${targetPath} already exists and is not empty. Assuming it's the repo.`);
+            return; // Or initialize git for this path: git.cwd(targetPath);
         }
-        makePathsRelative(tempTree, contentDir);
 
-        // Build the search index using the processed tree
-        await searchService.buildIndex(tempTree);
-
-        // If all operations succeed, assign the fully processed tree to the global variable
-        siteDirectoryTree = tempTree;
-        isInitialized = true;
-        console.log("Application data initialized successfully.");
+        console.log(`Cloning ${repoUrl} into ${targetPath}...`);
+        await git.clone(repoUrl, targetPath);
+        console.log("Repository cloned successfully.");
     } catch (error) {
-        console.error("Fatal error during app initialization:", error);
-        // siteDirectoryTree retains its default initialized value (empty but valid tree).
-        // isInitialized remains false, indicating that the full initialization was not successful.
-        // The application will run with an empty navigation but won't crash the template.
+        console.error(`Error cloning repository: ${error.message}`);
+        // Decide if this should be a fatal error
+        // process.exit(1);
+        throw error; // Re-throw to be handled by the caller
     }
 }
 
-// Middleware to make directory tree available to all requests
-app.use((req, res, next) => {
-    if (!isInitialized) {
-        // Could render a "initializing" page or wait, but for now, just proceed.
-        // It might mean the first few requests don't have the tree if initialization is slow.
-        // A better approach for production would be to ensure initialization completes before listening.
-        console.warn("App not fully initialized when request came in.");
+/**
+ * Pulls the latest changes for a repository at the given local path.
+ * @param {string} localPath - Local path of the repository.
+ */
+async function pullRepo(localPath) {
+    try {
+        const CWD = process.cwd();
+        const targetPath = path.resolve(CWD, localPath);
+
+        if (!await fs.pathExists(path.join(targetPath, '.git'))) {
+            console.error(`Error: ${targetPath} is not a git repository.`);
+            return;
+        }
+
+        console.log(`Pulling latest changes for repository at ${targetPath}...`);
+        // Important: Set the current working directory for simple-git instance for this operation
+        await simpleGit(targetPath).pull();
+        console.log("Repository up to date.");
+    } catch (error) {
+        console.error(`Error pulling repository: ${error.message}`);
+        throw error; // Re-throw to be handled by the caller
     }
-    res.locals.directoryTree = siteDirectoryTree;
-    next();
-});
+}
 
+/**
+ * Recursively lists all Markdown (.md) files in a given directory, excluding .git.
+ * @param {string} directoryPath - The absolute path to the directory to scan.
+ * @returns {Promise<string[]>} A list of relative paths to markdown files.
+ */
+async function listMarkdownFiles(basePath) {
+    const mdFiles = [];
+    const CWD = process.cwd();
+    const absoluteBasePath = path.resolve(CWD, basePath);
 
-// Routes
-// Index page - will display navigation and a welcome message or root readme
-app.get('/', async (req, res) => { // Made route async
-    let defaultContentHtml = null;
-    const defaultFilesToTry = ['index.md', 'README.md']; // Updated to prioritize index.md and remove GettingStarted.md
-    let foundFile = null;
-
-    for (const fileName of defaultFilesToTry) {
-        const filePath = path.join(contentDir, fileName);
-        try {
-            await fs.access(filePath); // Check if file exists and is accessible
-            const markdownContent = await fs.readFile(filePath, 'utf-8');
-            defaultContentHtml = marked.parse(markdownContent);
-            foundFile = fileName;
-            console.log(`Successfully loaded ${fileName} for the home page.`);
-            break; // Stop after finding the first available default file
-        } catch (error) {
-            if (error.code === 'ENOENT') {
-                console.log(`Default file ${fileName} not found in content directory. Trying next...`);
-            } else {
-                console.error(`Error accessing or reading ${fileName}:`, error);
+    async function findFiles(currentPath) {
+        const entries = await fs.readdir(currentPath, { withFileTypes: true });
+        for (const entry of entries) {
+            const fullEntryPath = path.join(currentPath, entry.name);
+            if (entry.isDirectory()) {
+                if (entry.name === '.git') {
+                    continue; // Skip .git directory
+                }
+                await findFiles(fullEntryPath);
+            } else if (entry.isFile() && entry.name.endsWith('.md')) {
+                mdFiles.push(path.relative(absoluteBasePath, fullEntryPath));
             }
         }
     }
 
-    if (!foundFile) {
-        console.log('No default content file (GettingStarted.md, index.md, or README.md) found in content directory.');
-    }
-
-    res.render('index', {
-        title: 'Home',
-        defaultContentHtml: defaultContentHtml, // Pass HTML to the template
-        // directoryTree is already in res.locals
-    });
-});
-
-// Placeholder for document view route (will be in a separate file later)
-const viewRoutes = require('./routes/view');
-app.use('/view', viewRoutes);
-
-// Search API endpoint
-app.get('/api/search', (req, res) => {
-    const query = req.query.q;
-    if (!query) {
-        return res.status(400).json({ error: 'Query parameter "q" is required.' });
-    }
     try {
-        const results = searchService.search(query);
-        // results are like: [{ path: 'relativePath', name: 'Document Name', score: 0.567 }]
-        res.json(results);
+        if (!await fs.pathExists(absoluteBasePath)) {
+            console.error(`Error: Directory ${absoluteBasePath} does not exist.`);
+            return [];
+        }
+        await findFiles(absoluteBasePath);
+        return mdFiles;
     } catch (error) {
-        console.error("Error in search API:", error);
-        res.status(500).json({ error: 'Search failed.' });
+        console.error(`Error listing markdown files: ${error.message}`);
+        return []; // Return empty list on error
     }
-});
-
-
-// Start the server after initialization
-async function startServer() {
-    await initializeApp(); // Ensure initialization is complete
-    app.listen(port, () => {
-        console.log(`Server listening at http://localhost:${port}`);
-    });
 }
 
-startServer();
 
-module.exports = app; // For potential testing
+/**
+ * Commits changes in the local repository.
+ * @param {string} localPath - The absolute path to the local repository.
+ * @param {string} message - The commit message.
+ * @param {string[]} filesToAdd - Array of file paths (relative to repo root) to add before committing.
+ */
+async function commitChanges(localPath, message, filesToAdd) {
+    try {
+        console.log(`Attempting to commit changes in ${localPath}...`);
+        const repoGit = simpleGit(localPath);
+
+        if (filesToAdd && filesToAdd.length > 0) {
+            for (const file of filesToAdd) {
+                await repoGit.add(file);
+                console.log(`Added ${file} to staging area.`);
+            }
+        } else {
+            console.log("No specific files provided to add. Committing existing staged changes if any.");
+        }
+
+        const statusAfterAdd = await repoGit.status();
+        if (statusAfterAdd.staged.length === 0) {
+            console.log("No changes were staged for commit. This might happen if the file wasn't modified or saved.");
+            // Optionally, ask user if they want to commit all changes or skip.
+            // For now, if `add` was called but nothing was staged (e.g. file not changed), this is noted.
+            // If commit is called with no staged changes, simple-git/git itself will likely error out or warn.
+            // We'll let that happen to provide natural git feedback.
+        }
+
+        await repoGit.commit(message);
+        console.log(`Changes committed with message: "${message}"`);
+    } catch (error) {
+        console.error(`Error committing changes: ${error.message}`);
+        if (error.message.includes("Please tell me who you are") || error.message.includes("user.name") || error.message.includes("user.email")) {
+            console.error("\nGit user identity (name and email) is not configured.");
+            console.error("Please configure it using the following commands and try again:");
+            console.error("  git config --global user.name \"Your Name\"");
+            console.error("  git config --global user.email \"youremail@example.com\"");
+        } else if (error.message.includes("nothing to commit")) {
+            console.warn("Commit failed: Nothing to commit. Ensure your file was saved and changed, or that there were other staged changes.");
+        }
+        throw error;
+    }
+}
+
+/**
+ * Pushes committed changes to the remote repository.
+ * @param {string} localPath - The absolute path to the local repository.
+ */
+async function pushChanges(localPath) {
+    try {
+        console.log(`Pushing changes from ${localPath} to remote...`);
+        const repoGit = simpleGit(localPath);
+
+        const status = await repoGit.status();
+        const currentBranch = status.current;
+
+        if (!currentBranch) {
+            console.error("Could not determine the current branch. Cannot push.");
+            throw new Error("Current branch could not be determined for push operation.");
+        }
+
+        console.log(`Pushing to remote 'origin' branch '${currentBranch}'...`);
+        await repoGit.push('origin', currentBranch, ['--set-upstream']);
+        console.log("Changes pushed successfully.");
+    } catch (error) {
+        console.error(`Error pushing changes: ${error.message}`);
+        console.error("\nPushing failed. Common reasons include:");
+        console.error("  - No internet connection.");
+        console.error("  - Incorrect repository URL or insufficient permissions (authentication failed).");
+        console.error("    (Ensure your PAT or SSH key is correctly set up with GitHub/your Git provider).");
+        console.error("  - Remote repository has new changes you need to pull first (run `git pull` manually or re-run the tool to pull).");
+        console.error("  - The local branch does not have a tracking relationship with a remote branch (the `--set-upstream` flag attempts to fix this for the first push).");
+        throw error;
+    }
+}
+
+
+async function main() {
+    console.log("Welcome to the Markdown Editor GitHub Tool (Node.js)!");
+
+    const questions = [
+        {
+            type: 'input',
+            name: 'repoUrl',
+            message: 'Enter the GitHub repository URL:',
+            validate: function (value) {
+                if (value.length && (value.startsWith('http://') || value.startsWith('https://') || value.startsWith('git@'))) {
+                    return true;
+                }
+                return 'Please enter a valid repository URL.';
+            },
+        },
+        {
+            type: 'input',
+            name: 'localPath',
+            message: 'Enter the local directory path for the clone (e.g., ./my-repo):',
+            default: './cloned_repo_nodejs', // Default value
+            validate: function (value) {
+                if (value.length) {
+                    return true;
+                }
+                return 'Please enter a local path.';
+            },
+        },
+    ];
+
+    const answers = await inquirer.prompt(questions);
+    const { repoUrl, localPath } = answers;
+    const absoluteLocalPath = path.resolve(process.cwd(), localPath);
+
+
+    try {
+        console.log(`Using repository URL: ${repoUrl}`);
+        console.log(`Using local path: ${absoluteLocalPath}`);
+
+        // Ensure the local path directory exists or try to create it
+        await fs.ensureDir(absoluteLocalPath);
+        console.log(`Ensured directory exists: ${absoluteLocalPath}`);
+
+        // Check if .git exists in localPath
+        const gitDirExists = await fs.pathExists(path.join(absoluteLocalPath, '.git'));
+
+        if (gitDirExists) {
+            console.log("Repository seems to exist locally. Pulling updates...");
+            await pullRepo(absoluteLocalPath);
+        } else {
+            // Check if directory is empty before cloning
+            const filesInDir = await fs.readdir(absoluteLocalPath);
+            if (filesInDir.length > 0) {
+                const { confirmClone } = await inquirer.prompt([{
+                    type: 'confirm',
+                    name: 'confirmClone',
+                    message: `Directory ${absoluteLocalPath} is not empty and not a git repo. Clone into it anyway? (This might overwrite existing files if they conflict with repo files)`,
+                    default: false
+                }]);
+                if (!confirmClone) {
+                    console.log("Cloning aborted by user.");
+                    return;
+                }
+            }
+            console.log("Cloning repository...");
+            await cloneRepo(repoUrl, absoluteLocalPath);
+        }
+
+        const markdownFiles = await listMarkdownFiles(absoluteLocalPath);
+        if (markdownFiles.length > 0) {
+            console.log("\nFound Markdown files:");
+            markdownFiles.forEach((file, index) => {
+                console.log(`  ${index + 1}. ${file}`);
+            });
+
+            const { selectedFile } = await inquirer.prompt([
+                {
+                    type: 'list',
+                    name: 'selectedFile',
+                    message: 'Select a markdown file to edit:',
+                    choices: markdownFiles,
+                    filter: function (val) { // Ensure we return the relative path
+                        return val;
+                    }
+                },
+            ]);
+
+            if (selectedFile) {
+                const fullFilePath = path.join(absoluteLocalPath, selectedFile);
+                console.log(`Opening ${fullFilePath}...`);
+                try {
+                    await open(fullFilePath);
+                    console.log(`File ${selectedFile} opened. Please edit and save it using your default markdown editor.`);
+
+                    const { readyToCommit } = await inquirer.prompt([
+                        {
+                            type: 'confirm',
+                            name: 'readyToCommit',
+                            message: 'Have you saved your changes and are you ready to commit them?',
+                            default: true,
+                        }
+                    ]);
+
+                    if (readyToCommit) {
+                        const { commitMessage } = await inquirer.prompt([
+                            {
+                                type: 'input',
+                                name: 'commitMessage',
+                                message: 'Enter your commit message:',
+                                validate: function(value) {
+                                    if (value.trim().length > 0) {
+                                        return true;
+                                    }
+                                    return 'Please enter a commit message.';
+                                }
+                            }
+                        ]);
+
+                        await commitChanges(absoluteLocalPath, commitMessage, [selectedFile]); // Pass selectedFile for specific add
+                        await pushChanges(absoluteLocalPath);
+                    } else {
+                        console.log("Commit and push aborted by user.");
+                    }
+
+                } catch (openError) {
+                    console.error(`Error opening file ${selectedFile}:`, openError);
+                }
+            }
+
+        } else {
+            console.log("No Markdown files found in the repository.");
+        }
+
+    } catch (error) {
+        console.error("An error occurred in the main workflow:", error.message);
+    }
+}
+
+main().catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,354 @@
         "express": "4.12.2",
         "express-ejs-layouts": "^2.5.1",
         "fs-extra": "^11.3.0",
+        "inquirer": "^12.6.3",
         "lunr": "^2.3.9",
-        "marked": "^16.0.0"
+        "marked": "^16.0.0",
+        "open": "^10.1.2",
+        "simple-git": "^3.28.0"
       }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
+      "integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+      "integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
+      "integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
+      "integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
+      "integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
+      "integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
+      "integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
+      "integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.1.8",
+        "@inquirer/confirm": "^5.1.12",
+        "@inquirer/editor": "^4.2.13",
+        "@inquirer/expand": "^4.0.15",
+        "@inquirer/input": "^4.1.12",
+        "@inquirer/number": "^3.0.15",
+        "@inquirer/password": "^4.0.15",
+        "@inquirer/rawlist": "^4.1.3",
+        "@inquirer/search": "^3.0.15",
+        "@inquirer/select": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
+      "integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
+      "integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
+      "integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@kwsites/file-exists/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.2.13",
@@ -28,6 +373,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -67,6 +436,21 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -81,6 +465,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/color-convert": {
@@ -154,6 +553,46 @@
         "ms": "0.7.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz",
@@ -189,6 +628,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/escape-html": {
       "version": "1.0.1",
@@ -246,6 +691,20 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/express-ejs-layouts/-/express-ejs-layouts-2.5.1.tgz",
       "integrity": "sha512-IXROv9n3xKga7FowT06n1Qn927JR8ZWDn5Dc9CJQoiiaaDqbhW5PDmWShzbpAa2wjWT1vJqaIM1S6vJwwX11gA=="
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -338,6 +797,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inquirer": {
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.6.3.tgz",
+      "integrity": "sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/prompts": "^7.5.3",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "mute-stream": "^2.0.0",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
@@ -345,6 +842,63 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jake": {
@@ -465,6 +1019,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz",
       "integrity": "sha512-YmuMMkfOZzzAftlHwiQxFepJx/5rDaYi9o9QanyBCk485BRAyM/vB9XoYlZvglxE/pmAWOiQgrdoE10watiK9w=="
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz",
@@ -484,6 +1047,33 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.2.tgz",
+      "integrity": "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/parseurl": {
@@ -526,6 +1116,42 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/send": {
       "version": "0.12.1",
@@ -610,6 +1236,82 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-git": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/simple-git/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/simple-git/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -620,6 +1322,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -659,6 +1391,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,30 +1,28 @@
 {
-  "name": "app",
+  "name": "markdown-github-editor-cli",
   "version": "1.0.0",
-  "description": "Looking at Googles gemini-ai functionality",
-  "main": "index.js",
+  "description": "A CLI tool to clone a GitHub repo, edit markdown files, and push changes.",
+  "main": "app.js",
+  "type": "module",
   "scripts": {
     "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/StephenBooysen/gemini-cli.git"
-  },
-  "keywords": [],
+  "keywords": [
+    "git",
+    "markdown",
+    "cli",
+    "editor"
+  ],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
-  "bugs": {
-    "url": "https://github.com/StephenBooysen/gemini-cli/issues"
-  },
-  "homepage": "https://github.com/StephenBooysen/gemini-cli#readme",
   "dependencies": {
-    "ejs": "^3.1.10",
-    "express": "4.12.2",
-    "fs-extra": "^11.3.0",
-    "lunr": "^2.3.9",
-    "marked": "^16.0.0",
-    "express-ejs-layouts": "^2.5.1"
-  }
+    "fs-extra": "^11.2.0",
+    "inquirer": "^9.2.20",
+    "open": "^10.1.0",
+    "simple-git": "^3.22.0"
+  },
+  "repository": {},
+  "bugs": {},
+  "homepage": ""
 }


### PR DESCRIPTION
This commit introduces a Node.js command-line application that allows users to:
- Clone a GitHub repository or pull updates from an existing local clone.
- List markdown files within the repository.
- Select a markdown file to open in the system's default editor.
- Commit the changes with a user-provided message.
- Push the changes back to the GitHub repository (origin/current branch).

The application uses `simple-git` for Git operations, `inquirer` for interactive prompts, `fs-extra` for file system utilities, and `open` to launch the editor.

Includes error handling for common Git scenarios and user-friendly prompts to guide the workflow.

Also includes a README.md with setup and usage instructions.