### PR TITLE
feat: Add express-ejs-layouts for server-side templating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "ejs": "^3.1.9",
         "express": "^4.18.2",
+        "express-ejs-layouts": "^2.5.1",
         "fs-extra": "^11.2.0",
         "inquirer": "^9.2.20",
         "marked": "^4.0.10",
@@ -762,6 +763,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-ejs-layouts": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/express-ejs-layouts/-/express-ejs-layouts-2.5.1.tgz",
+      "integrity": "sha512-IXROv9n3xKga7FowT06n1Qn927JR8ZWDn5Dc9CJQoiiaaDqbhW5PDmWShzbpAa2wjWT1vJqaIM1S6vJwwX11gA=="
     },
     "node_modules/external-editor": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "simple-git": "^3.22.0",
     "express": "^4.18.2",
     "ejs": "^3.1.9",
+    "express-ejs-layouts": "^2.5.1",
     "marked": "^4.0.10"
   },
   "repository": {},

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import expressLayouts from 'express-ejs-layouts';
 import { getDirectoryTree } from './services/fileService.js';
 import viewRoutes from './routes/view.js';
 
@@ -16,6 +17,8 @@ const contentDir = path.join(__dirname, 'content');
 // View engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
+app.use(expressLayouts);
+app.set('layout', 'layout'); // This tells ejs-layouts to use views/layout.ejs
 
 // Serve static files
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
- Installs express-ejs-layouts and adds it to dependencies.
- Configures the Express app in server.js to use ejs-layouts, setting views/layout.ejs as the default layout.
- Verifies that routes/view.js and views/layout.ejs are compatible with the new layout system.

This change enables the server to use a consistent layout for all rendered pages, moving away from placeholder content.